### PR TITLE
Track fetch output so scheduled runs persist data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,3 @@ CLAUDE.md
 # Downloaded data (keep directory)
 downloaded/*
 !downloaded/.gitkeep
-
-# Processed data (keep directory)
-processed/*
-!processed/.gitkeep


### PR DESCRIPTION
Scheduled fetch downloaded this source every day and discarded the result, because `.gitignore` excluded `processed/`. New entries never reached the repository. Dropped the ignore rule so fetch output is tracked and each run persists what it downloaded.

No workflow change is needed here: `fetch.yml` already restricts its commit and issue-filing steps to the default branch.
